### PR TITLE
Fix detecting binary files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+* text=auto eol=lf

--- a/recommended/gitattributes
+++ b/recommended/gitattributes
@@ -1,3 +1,3 @@
-* text eol=lf
+* text=auto eol=lf
 *.ipynb filter=nbstripout
 *.ipynb diff=ipynb


### PR DESCRIPTION
- Using "* text=auto eol=lf", needs git version >= 2.10.
- Alternatively use explicit listing of binaries like "*.png binary"