### PR TITLE
Add http.sslVerify=false on prod-linux

### DIFF
--- a/recommended/gitconfig-prod-linux
+++ b/recommended/gitconfig-prod-linux
@@ -18,6 +18,8 @@
 	clean = '/usr/bin/python3' -m nbstripout
 	extrakeys = metadata.kernelspec metadata.language_info.version cell.metadata.pycharm metadata.language_info.pygments_lexer metadata.language_info.codemirror_mode.version
 	smudge = cat
+[http]
+	sslVerify = false
 [merge]
 	tool = meld
 [mergetool]

--- a/ssb-gitconfig/ssb-gitconfig.py
+++ b/ssb-gitconfig/ssb-gitconfig.py
@@ -172,7 +172,9 @@ def set_base_config(pl: Platform) -> str:
 
     with TempDir(temp_dir):
         options = []
-        if pl.prod_zone and pl.windows and pl.citrix:
+        prod_zone_windows = pl.prod_zone and pl.windows and pl.citrix
+        prod_zone_linux = pl.prod_zone and pl.linux
+        if prod_zone_windows or prod_zone_linux:
             options = ["-c", "http.sslVerify=False"]
 
         cmd = (


### PR DESCRIPTION
- Some configuration must have been changed in the prod zone, because this setting is now needed for terminals with git 1.x in the prod zone.