### PR TITLE
Set default branch and use current branch when push

### DIFF
--- a/recommended/gitconfig-adm-mac
+++ b/recommended/gitconfig-adm-mac
@@ -6,10 +6,12 @@
 	eol = lf
 [fetch]
 	prune = true
+[init]
+	defaultBranch = main
 [merge]
 	tool = meld
 [mergetool]
 	keepBackup = false
 	prompt = false
 [push]
-	default = simple
+	default = current

--- a/recommended/gitconfig-dapla
+++ b/recommended/gitconfig-dapla
@@ -14,3 +14,7 @@
 	clean = '/opt/conda/bin/python3' -m nbstripout
 	extrakeys = metadata.kernelspec metadata.language_info.version cell.metadata.pycharm metadata.language_info.pygments_lexer metadata.language_info.codemirror_mode.version
 	smudge = cat
+[init]
+	defaultBranch = main
+[push]
+	default = current

--- a/recommended/gitconfig-prod-linux
+++ b/recommended/gitconfig-prod-linux
@@ -20,10 +20,12 @@
 	smudge = cat
 [http]
 	sslVerify = false
+[init]
+	defaultBranch = main
 [merge]
 	tool = meld
 [mergetool]
 	keepBackup = false
 	prompt = false
 [push]
-	default = simple
+	default = current

--- a/recommended/gitconfig-prod-windows-citrix
+++ b/recommended/gitconfig-prod-windows-citrix
@@ -8,6 +8,8 @@
 	prompt = false
 [http]
 	sslVerify = false
+[init]
+	defaultBranch = main
 [merge]
 	tool = meld
 [mergetool]
@@ -15,3 +17,5 @@
 	keepBackup = false
 [mergetool "meld"]
 	path = "C:/Program Files (x86)/Meld/Meld.exe"
+[push]
+	default = current


### PR DESCRIPTION
- Newer version of git complains if no default branch name is set. This config sets the default branch name to "main".
- Setting push.default to current prevents git from complaining about no upstream branch set when pushing the branch for the first time.
  You no longer has to type: git push --set-upstream origin mybranch.