### PR TITLE
Feature/validation argument

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 2.1.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/kvakk_git_tools/ssb_gitconfig.py
+++ b/kvakk_git_tools/ssb_gitconfig.py
@@ -9,7 +9,7 @@ If there is an existing .gitconfig file, it is backed up, and the name and email
 address are extracted from it and reused.
 """
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 import argparse
 import getpass
@@ -219,7 +219,7 @@ def set_base_config(pl: Platform, test: bool) -> str:
     if test:
         src = config_dir / "gitconfig-dapla"
 
-    options = ["--branch", "2.0.0"]
+    options = ["--branch", "2.1.0"]
     prod_zone_windows = pl.name() is PlatformName.PROD_WINDOWS_CITRIX
     prod_zone_linux = pl.name() is PlatformName.PROD_LINUX
     if prod_zone_windows or prod_zone_linux:

--- a/kvakk_git_tools/ssb_gitconfig.py
+++ b/kvakk_git_tools/ssb_gitconfig.py
@@ -312,7 +312,7 @@ def kvakk_git_tools_package_installed() -> bool:
 def enable_additional_package_arguments(
     parser: argparse.ArgumentParser, enable: bool
 ) -> None:
-    """Enables additional package arguments in the given ArgumentParser object.
+    """Enables packages specific arguments in the given ArgumentParser object.
 
     Args:
         parser (argparse.ArgumentParser): The ArgumentParser object.

--- a/poetry.lock
+++ b/poetry.lock
@@ -340,6 +340,21 @@ files = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.1.1"
+description = "Backport of PEP 654 (exception groups)"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "exceptiongroup-1.1.1-py3-none-any.whl", hash = "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e"},
+    {file = "exceptiongroup-1.1.1.tar.gz", hash = "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
 name = "filelock"
 version = "3.9.0"
 description = "A platform independent file lock."
@@ -562,6 +577,18 @@ python-versions = ">=3.5"
 files = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
     {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
 
 [[package]]
@@ -803,6 +830,18 @@ files = [
 setuptools = "*"
 
 [[package]]
+name = "packaging"
+version = "23.1"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
+    {file = "packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
+]
+
+[[package]]
 name = "pathspec"
 version = "0.11.0"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -841,6 +880,22 @@ files = [
 [package.extras]
 docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
@@ -947,6 +1002,29 @@ tomlkit = ">=0.10.1"
 [package.extras]
 spelling = ["pyenchant (>=3.2,<4.0)"]
 testutils = ["gitpython (>3)"]
+
+[[package]]
+name = "pytest"
+version = "7.3.1"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-7.3.1-py3-none-any.whl", hash = "sha256:3799fa815351fea3a5e96ac7e503a96fa51cc9942c3753cda7651b93c1cfa362"},
+    {file = "pytest-7.3.1.tar.gz", hash = "sha256:434afafd78b1d78ed0addf160ad2b77a30d35d4bdf8af234fe621919d9ed15e3"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "pyyaml"
@@ -1341,4 +1419,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7dd9ec0052832b83e1640219ae58bed944fb2edb46f474cf799fcede6f48f403"
+content-hash = "4d3aed2d991d321db41fde3c3becfb6723eaaa276ca1a5df7366180f75b58e05"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ pre-commit = "^2.20.0"
 pre-commit-hooks = "^4.3.0"
 pylint = "^2.15.3"
 bump2version = "*"
+pytest = "^7.3.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kvakk-git-tools"
-version = "2.0.0"
+version = "2.1.0"
 description = "Recommended git config and git scripts for Statistics Norway."
 authors = ["Arne Sørli <81353974+arneso-ssb@users.noreply.github.com>"]
 license = "MIT"

--- a/tests/test_ssb_gitconfig.py
+++ b/tests/test_ssb_gitconfig.py
@@ -1,0 +1,52 @@
+"""Test module for ssb_gitconfig."""
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+from kvakk_git_tools import run
+
+
+@pytest.mark.parametrize("validate_return,exit_code", [(True, 0), (False, 1)])
+@patch("kvakk_git_tools.validate_ssb_gitconfig.validate_git_config")
+@patch("kvakk_git_tools.ssb_gitconfig.kvakk_git_tools_package_installed")
+def test_run_package_installed(
+    mock_package_installed: Mock,
+    mock_validate: Mock,
+    validate_return: bool,
+    exit_code: int,
+) -> None:
+    # Checks that the program exposes the --validate argument when
+    # kvakk-git-tools package is installed and exits with 0/1
+    # based on what the validate function returns.
+    sys.argv = ["", "--validate"]
+    mock_validate.return_value = validate_return
+    mock_package_installed.return_value = True
+    with pytest.raises(SystemExit) as sys_exit:
+        run()
+    assert sys_exit.value.code == exit_code
+
+
+@patch("kvakk_git_tools.ssb_gitconfig.kvakk_git_tools_package_installed")
+def test_run_package_not_installed(mock_package_installed: Mock) -> None:
+    # Checks that the program does not expose the --validate argument when
+    # kvakk-git-tools package is not installed
+    mock_package_installed.return_value = False
+    sys.argv = ["", "--validate"]
+    with pytest.raises(SystemExit) as sys_exit:
+        run()
+    assert sys_exit.value.code == 2  # Should return 2 unknown argument
+
+
+@pytest.mark.parametrize("package_installed", [True, False])
+@patch("kvakk_git_tools.ssb_gitconfig.main")
+@patch("kvakk_git_tools.ssb_gitconfig.kvakk_git_tools_package_installed")
+def test_run_package_no_args(
+    mock_package_installed: Mock, mock_main: Mock, package_installed: bool
+) -> None:
+    # Checks that main runs when no args are supplied to the program
+    # independent of package installation.
+    mock_package_installed.return_value = package_installed
+    sys.argv = [""]
+    run()
+    assert mock_main.called


### PR DESCRIPTION
This release adds the option of running `kvakk-git-tools --validate` to check if your global gitconfig is following SSB recommendations.

- Add validate argument (This argument is only available when package is installed).
- Write test for the --validate argument