### PR TITLE
Suppress git clone output

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.0
+current_version = 2.1.1
 commit = True
 tag = True
 tag_name = {new_version}

--- a/kvakk_git_tools/ssb_gitconfig.py
+++ b/kvakk_git_tools/ssb_gitconfig.py
@@ -9,7 +9,7 @@ If there is an existing .gitconfig file, it is backed up, and the name and email
 address are extracted from it and reused.
 """
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 import argparse
 import getpass
@@ -219,7 +219,7 @@ def set_base_config(pl: Platform, test: bool) -> str:
     if test:
         src = config_dir / "gitconfig-dapla"
 
-    options = ["--branch", "2.1.0"]
+    options = ["--branch", "2.1.1"]
     prod_zone_windows = pl.name() is PlatformName.PROD_WINDOWS_CITRIX
     prod_zone_linux = pl.name() is PlatformName.PROD_LINUX
     if prod_zone_windows or prod_zone_linux:

--- a/kvakk_git_tools/ssb_gitconfig.py
+++ b/kvakk_git_tools/ssb_gitconfig.py
@@ -235,7 +235,7 @@ def set_base_config(pl: Platform, test: bool) -> str:
     # Fix for python < 3.7, using stdout.
     # Use capture_output=true instead of stdout when python >= 3.7
     with TempDir(temp_dir):
-        subprocess.run(cmd, cwd=temp_dir, stdout=subprocess.DEVNULL, check=True)
+        subprocess.run(cmd, cwd=temp_dir, stderr=subprocess.DEVNULL, check=True)
         dst.write_bytes(src.read_bytes())
 
         # Replace template username with real username

--- a/kvakk_git_tools/ssb_gitconfig.py
+++ b/kvakk_git_tools/ssb_gitconfig.py
@@ -235,7 +235,7 @@ def set_base_config(pl: Platform, test: bool) -> str:
     # Fix for python < 3.7, using stdout.
     # Use capture_output=true instead of stdout when python >= 3.7
     with TempDir(temp_dir):
-        subprocess.run(cmd, cwd=temp_dir, stdout=subprocess.PIPE, check=True)
+        subprocess.run(cmd, cwd=temp_dir, stdout=subprocess.DEVNULL, check=True)
         dst.write_bytes(src.read_bytes())
 
         # Replace template username with real username

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kvakk-git-tools"
-version = "2.1.0"
+version = "2.1.1"
 description = "Recommended git config and git scripts for Statistics Norway."
 authors = ["Arne Sørli <81353974+arneso-ssb@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
The git clone output was cluttering the users terminal with the print below. This PR suppress output from git clone command.
```
Cloning into 'kvakk-git-tools'...
remote: Enumerating objects: 429, done.
remote: Counting objects: 100% (127/127), done.
remote: Compressing objects: 100% (70/70), done.
remote: Total 429 (delta 74), reused 87 (delta 53), pack-reused 302
Receiving objects: 100% (429/429), 185.66 KiB | 1.84 MiB/s, done.
Resolving deltas: 100% (218/218), done.
Note: switching to 'c252c633856edde84fdda8664eb5199cc113ac01'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

A new /home/jovyan/.gitconfig created successfully.
```

