### PR TITLE
fix bug in .gitconfig validation logic

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.4
+current_version = 2.3.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1719848872,
+        "narHash": "sha256-H3+EC5cYuq+gQW8y0lSrrDZfH71LB4DAf+TDFyvwCNA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "00d80d13810dbfea8ab4ed1009b09100cca86ba8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1719876945,
+        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "kvakk-git-tools dev env";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = inputs @ {flake-parts, ...}:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"];
+      perSystem = {
+        pkgs,
+        lib,
+        ...
+      }: {
+        devShells.default = pkgs.mkShell {
+          name = "ssb-project-cli";
+          packages =
+            (with pkgs; [
+              nixd
+              python310
+              python311
+              python312
+              python311Packages.ruff-lsp
+              (poetry.override {python3 = python312;})
+            ])
+            ++ lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
+              Cocoa
+              CoreServices
+            ]);
+        };
+
+        formatter = pkgs.alejandra;
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
           name = "ssb-project-cli";
           packages =
             (with pkgs; [
+              bump2version
               nixd
               python310
               python311

--- a/kvakk_git_tools/ssb_gitconfig.py
+++ b/kvakk_git_tools/ssb_gitconfig.py
@@ -9,7 +9,7 @@ If there is an existing .gitconfig file, it is backed up, and the name and email
 address are extracted from it and reused.
 """
 
-__version__ = "2.2.4"
+__version__ = "2.3.0"
 
 import argparse
 import getpass

--- a/kvakk_git_tools/validate_ssb_gitconfig.py
+++ b/kvakk_git_tools/validate_ssb_gitconfig.py
@@ -1,5 +1,6 @@
 """This module provides functions for validating SSB Git configuration."""
 
+import configparser
 import sys
 from pathlib import Path
 
@@ -43,6 +44,8 @@ def _validate_platform_git_config(
         f"recommended/gitconfig-{detected_platform.name().value}"
     )
 
+    ssb_config = configparser.ConfigParser()
+
     # If python version is older than 3.10 use stdlib module which is now deprecated.
     if sys.version_info.major == 3 and sys.version_info.minor < 10:
         import pkg_resources
@@ -50,43 +53,53 @@ def _validate_platform_git_config(
         with pkg_resources.resource_stream(
             __package__, ssb_recommended_config_file_path
         ) as ssb_config_file:
-            ssb_config_contents = ssb_config_file.read()
-            ssb_config_contents_str = ssb_config_contents.decode("utf-8")
+            ssb_config.read_string(ssb_config_file.read().decode("utf-8"))
     else:
         from importlib.resources import files
 
         with files(__package__).joinpath(ssb_recommended_config_file_path).open(
             "rb"
         ) as ssb_config_file:
-            ssb_config_contents = ssb_config_file.read()
-            ssb_config_contents_str = ssb_config_contents.decode("utf-8")
+            ssb_config.read_string(ssb_config_file.read().decode("utf-8"))
 
-    with open(git_config_path) as local_config_file:
-        local_config_contents = local_config_file.read()
+    with open(git_config_path, "r") as local_config_file:
+        local_config = configparser.ConfigParser()
+        local_config.read_string(local_config_file.read())
 
-    ssb_config_lines = ssb_config_contents_str.split("\n")
-    local_config_lines = local_config_contents.split("\n")
-    if ssb_config_lines == local_config_lines:
-        return True
-    else:
-        rest = [line for line in local_config_lines if line not in ssb_config_lines]
-        return _verify_configuration_difference(rest)
+    ssb_config = {
+        section: dict(ssb_config.items(section)) for section in ssb_config.sections()
+    }
 
+    local_config = {
+        section: dict(local_config.items(section))
+        for section in local_config.sections()
+    }
 
-def _verify_configuration_difference(rest: list[str]) -> bool:
-    """Checks that the difference in configuration is only [user], name, and email.
-
-    Args:
-        rest (list[str]): A list containing the elements to check.
-
-    Returns:
-        bool: True if the difference contains only [user], name, and email settings. False otherwise.
-    """
-    if len(rest) != 3:
+    # If the [user] section exists ensure that both
+    # name and email fields are set
+    if "user" in local_config and not all(
+        key in local_config["user"] for key in ("name", "email")
+    ):
         return False
 
-    # Check that the rest of the configuration contains [user], name, and email in the expected order
-    if "[user]" in rest[0] and "\tname =" in rest[1] and "\temail =" in rest[2]:
-        return True
+    return all(
+        _check_config(value, local_config, section, key)
+        for section in ssb_config
+        for key, value in ssb_config[section].items()
+    )
 
-    return False
+
+def _check_config(
+    expected_value: str,
+    actual_conf: dict[str, dict[str, str]],
+    section: str,
+    key: str,
+) -> bool:
+    """Ensure that the section and key exist in the configuraton
+    and that the value equals the expected value."""
+    if section not in actual_conf:
+        return False
+    if key not in actual_conf[section]:
+        return False
+
+    return expected_value == actual_conf[section][key]

--- a/kvakk_git_tools/validate_ssb_gitconfig.py
+++ b/kvakk_git_tools/validate_ssb_gitconfig.py
@@ -95,8 +95,11 @@ def _check_config(
     section: str,
     key: str,
 ) -> bool:
-    """Ensure that the section and key exist in the configuraton
-    and that the value equals the expected value."""
+    """Check corectness of configuration.
+
+    Ensure that the `section` and `key` exist in the configuraton
+    and that the value equals the expected value.
+    """
     if section not in actual_conf:
         return False
     if key not in actual_conf[section]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kvakk-git-tools"
-version = "2.2.4"
+version = "2.3.0"
 description = "Recommended git config and git scripts for Statistics Norway."
 authors = ["Arne Sørli <81353974+arneso-ssb@users.noreply.github.com>"]
 license = "MIT"

--- a/tests/test_files/config_with_extra.test
+++ b/tests/test_files/config_with_extra.test
@@ -1,0 +1,31 @@
+[color]
+	ui = auto
+[core]
+	autocrlf = input
+	editor = nano
+	eol = lf
+[credential]
+	helper = cache --timeout=86400
+[diff "ipynb"]
+	textconv = '/opt/conda/bin/python3' -m nbstripout -t
+[fetch]
+	prune = true
+[filter "nbstripout"]
+	clean = '/opt/conda/bin/python3' -m nbstripout
+	extrakeys = metadata.kernelspec metadata.language_info.version cell.metadata.pycharm metadata.language_info.pygments_lexer metadata.language_info.codemirror_mode.version
+	smudge = cat
+[init]
+	defaultBranch = main
+[push]
+	default = current
+	followTags = true
+	autoSetupRemote = true
+[pull]
+	rebase = true
+[user]
+	name = Donald Duck
+	email = donald-duck@andeby.no
+[credential "https://github.com"]
+    helper = !/run/current-system/sw/bin/gh auth git-credential
+[credential "https://gist.github.com"]
+    helper = !/run/current-system/sw/bin/gh auth git-credential

--- a/tests/test_validate_gitconfig.py
+++ b/tests/test_validate_gitconfig.py
@@ -39,8 +39,10 @@ def test_validate_git_config_equal() -> None:
 
 
 def test_validate_git_config_with_extra_fields() -> None:
-    """Test that a git configuration with additional fields on top
-    of the recommended setup for a specific platform is considered valid by `validate_platform_git_config()`
+    """Test the functionality of `validate_platform_git_config()` on a configuration file with extra fields.
+
+    Test that a git configuration with additional fields on top
+    of the recommended setup for a specific platform is considered valid by `validate_platform_git_config()`.
     """
     detected_platform = _mock_platform_name(PlatformName.DAPLA)
     git_config_path = "tests/test_files/config_with_extra.test"

--- a/tests/test_validate_gitconfig.py
+++ b/tests/test_validate_gitconfig.py
@@ -38,6 +38,15 @@ def test_validate_git_config_equal() -> None:
         )
 
 
+def test_validate_git_config_with_extra_fields() -> None:
+    """Test that a git configuration with additional fields on top
+    of the recommended setup for a specific platform is considered valid by `validate_platform_git_config()`
+    """
+    detected_platform = _mock_platform_name(PlatformName.DAPLA)
+    git_config_path = "tests/test_files/config_with_extra.test"
+    assert _validate_platform_git_config(git_config_path, detected_platform)
+
+
 def test_validate_git_config_not_equal() -> None:
     """Test the functionality of `validate_platform_git_config()` with an invalid configuration file.
 


### PR DESCRIPTION
make validation more flexible by parsing
the actual fields of the configuration instead
of comparing lines in the config.


Ref: https://statistics-norway.atlassian.net/browse/DPSTAT-1073